### PR TITLE
Implement 3-col header layout (no indent for sub-headings yet though)

### DIFF
--- a/resume.css
+++ b/resume.css
@@ -31,6 +31,8 @@ h2 {
 
 h3 {
   font-weight: normal;
+  border-bottom: 1px solid #888;
+  padding-bottom: 4px;
 }
 
 /*

--- a/resume.css
+++ b/resume.css
@@ -25,6 +25,41 @@ h2 {
   font-size: 16px;
 }
 
+/*
+For all tables (assuming all will have 3 columns!),
+align left col to the left, center to center, and right to right.
+ */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table th:first-child {
+  text-align: left;
+}
+table td:first-child {
+  text-align: left;
+}
+
+table th:nth-child(2) {
+  text-align: center;
+}
+table td:nth-child(2) {
+  text-align: center;
+}
+
+table th:last-child {
+  text-align: right;
+}
+table td:last-child {
+  text-align: right;
+}
+
+/* Markdown single-row tables produce th, not td. Remove header styling. */
+th {
+  font-weight: normal;
+}
+
 /* Render bullet-point lists with dashes */
 ul {
   list-style-type: none;

--- a/resume.css
+++ b/resume.css
@@ -1,7 +1,7 @@
 body {
   padding: 00px;
-  font-family: "Helvetica", sans-serif;
-  font-size: 16px;
+  font-family: "Helvetica", "Inter", sans-serif;
+  font-size: 12px;
 }
 
 /* Don't render links */
@@ -15,14 +15,21 @@ h1, h2 {
 }
 
 h1 {
-  font-size: 26px;
+  font-size: 16px;
+  margin: 0;
 }
 
 h2 {
-  margin-top: 30px;
+  margin-top: 16px;
   border-bottom: 1px solid black;
-  padding-bottom: 10px; /* Optional: Adds some space between the heading and the line */
-  font-size: 16px;
+  padding-bottom: 4px;
+  font-size: 14px;
+}
+
+h3 {
+  font-size: 14px;
+  text-transform: uppercase;
+  font-weight: normal;
 }
 
 /*
@@ -31,6 +38,7 @@ align left col to the left, center to center, and right to right.
  */
 table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
 }
 

--- a/resume.css
+++ b/resume.css
@@ -10,25 +10,26 @@ body a {
     color: inherit;
 }
 
-h1, h2 {
+h1, h2, h3 {
   text-transform: uppercase;
 }
 
 h1 {
-  font-size: 16px;
+  font-size: 14px;
   margin: 0;
+}
+
+h2, h3 {
+  font-size: 12px;
 }
 
 h2 {
   margin-top: 16px;
   border-bottom: 1px solid black;
   padding-bottom: 4px;
-  font-size: 14px;
 }
 
 h3 {
-  font-size: 14px;
-  text-transform: uppercase;
   font-weight: normal;
 }
 

--- a/resume.md
+++ b/resume.md
@@ -9,56 +9,80 @@ Swift, Objective-C, iOS, Dart, Flutter, Bitrise, GitHub Actions, Firebase, Fastl
 
 ## Experience
 
-| **Retro Rabbit Enterprise Services**  | **Senior software developer** | **2016 – present** |
+| **Senior software developer** | **Retro Rabbit Enterprise Services**  | **2016 – present** |
 | -- | -- | -- |
 
-Client projects:
+<!-- TODO: Visually, it looks great if there are 3 bullet points or a paragraph here. Consider adding an overview. -->
 
-| Discovery Limited – Health App | Mobile technical lead | 2023 – 2024 |
+### Client projects
+
+| *Mobile technical lead* | *Discovery Limited* | *2023 – 2024* |
+| -- | -- | -- |
+| Health App | South Africa | |
+
+- Co-led team of 8 implementing new Flutter-based mobile app for South Africa's largest medical scheme with 2.8M customers
+- Designed library of modules to be reusable company-wide through a process of proposing RFCs, writing abstract interfaces, and releasing standalone federated plugins
+- Instilled usage of BLoC, dependency injection, and feature flag patterns through reference implementations and code reviews
+- Set up release pipelines on GitHub Actions and Bitrise into Firebase App Distribution, App Store Connect and Google Play to provide QA with nightly builds and streamline app store releases, enabling anyone on the team to go live
+- Integrated in-house iOS-native biometric authentication SDK as a Flutter plugin, connecting native Swift code to Dart, improving user experience and aligning with organisation security standards <!--NOTE: Change organisation to organization if applying in US-->
+- Engaged stakeholders, converting business cases to road maps with linked issues, reporting regularly on install- and crash stats, and proactively communicating roadblocks  
+
+| *iOS technical lead* | *Discovery Limited* | *2022-2023* |
+| -- | -- | -- |
+| Health Module for Mobile App | South Africa | |
+
+- Maintained Swift- and Objective-C-based native iOS code modules providing all personal and company-issued medical insurance functionality across 4 independent schemes to 3M+ customers
+- Coordinated and participated in production support, addressing user issues and collaborating across teams to drive problem resolution
+- Implemented version-bump automation in GitHub Actions and Fastlane to unblock code merging conflicts and improve team throughput
+- Introduced SwiftLint to keep code reviews focused on content over style
+- Translated high-level stakeholder feature requests to implementation plans in absence of business representation
+
+| *Team lead* | *Kalido* | *2016 – 2022* |
+| -- | -- | -- |
+| iOS squad | UK | |
+
+- Led team of 4 in developing native iOS app for UK-based talent marketplace product that was named a [World Economic Forum Technology Pioneer in 2020](https://widgets.weforum.org/techpioneers-2020/kalido/)
+- Implemented and released dozens of features, including real-time, scalable, multi-user, multimedia-enabled messaging using bidirectional gRPC streams with Realm caching
+- Designed APIs using Protocol Buffers and maintained a Go-based backend-for-mobile service layer, keeping data transmissions maximally efficient without complicating core server implementation
+- Refactored features to be toggle-able by Firebase feature flags, enabling demos of pre-release features, as well as real-time response to production issues
+- Introduced modularisation to 100k+ line codebase, improving build times and developer efficiency <!--NOTE: Change modularisation to modularization if applying in US-->
+- Triaged and fixed hundreds of production user issues
+
+### Internal contributions
+
+| *Committee chair* | *Knowledge Ninjas* | *2019 – 2024*  |
 | -- | -- | -- |
 
-  - Co-led team of 8 implementing new Flutter-based mobile app for South Africa's largest medical scheme with 2.8M customers
-  - Designed library of modules to be reusable company-wide through a process of proposing RFCs, writing abstract interfaces, and releasing standalone federated plugins
-  - Instilled usage of BLoC, dependency injection, and feature flag patterns through reference implementations and code reviews
-  - Set up release pipelines on GitHub Actions and Bitrise into Firebase App Distribution, App Store Connect and Google Play to provide QA with nightly builds and streamline app store releases, enabling anyone on the team to go live
-  - Integrated in-house iOS-native biometric authentication SDK as a Flutter plugin, connecting native Swift code to Dart, improving user experience and aligning with organisation security standards <!--NOTE: Change organisation to organization if applying in US-->
-  - Engaged stakeholders, converting business cases to road maps with linked issues, reporting regularly on install- and crash stats, and proactively communicating roadblocks  
+- Co-chaired committee aimed at fostering a culture of continuous learning and knowledge sharing within the company
+- Co-organised 3 internal conferences, showcasing a total of 34 speakers to 500+ attendees <!--NOTE: Change organised to organized if applying in US-->
+- Organised a continuous stream of technical talks by internal and external speakers, in addition to other initiatives and activities, keeping employees engaged and stimulated <!--NOTE: Change organised to organized if applying in US-->
 
-- **Discovery Limited – Health Module** | iOS technical lead | 2022-2023
-  - Maintained Swift- and Objective-C-based native iOS code modules providing all personal and company-issued medical insurance functionality across 4 independent schemes to 3M+ customers
-  - Coordinated and participated in production support, addressing user issues and collaborating across teams to drive problem resolution
-  - Implemented version-bump automation in GitHub Actions and Fastlane to unblock code merging conflicts and improve team throughput
-  - Introduced SwiftLint to keep code reviews focused on content over style
-  - Translated high-level stakeholder feature requests to implementation plans in absence of business representation
+| *Chief editor* | *Company blog* | *2020 – present* |
+| -- | -- | -- |
 
-- **Kalido** | iOS lead | 2016 – 2022
-  - Led team of 4 in developing native iOS app for UK-based talent marketplace product that was named a [World Economic Forum Technology Pioneer in 2020](https://widgets.weforum.org/techpioneers-2020/kalido/)
-  - Implemented and released dozens of features, including real-time, scalable, multi-user, multimedia-enabled messaging using bidirectional gRPC streams with Realm caching
-  - Designed APIs using Protocol Buffers and maintained a Go-based backend-for-mobile service layer, keeping data transmissions maximally efficient without complicating core server implementation
-  - Refactored features to be toggle-able by Firebase feature flags, enabling demos of pre-release features, as well as real-time response to production issues
-  - Introduced modularisation to 100k+ line codebase, improving build times and developer efficiency <!--NOTE: Change modularisation to modularization if applying in US-->
-  - Triaged and fixed hundreds of production user issues
+- Recruited authors internally and reviewed, edited and published posts, ensuring the company website had a steady stream of interesting and relevant content at a high standard of writing
 
-Internal contributions:
+| *Pilot participant and mentor* | *Mentorship program* | *2023 – present* |
+| -- | -- | -- |
 
-- **Knowledge Ninjas** | Committee chair | 2019 – 2023  
-  - Co-chaired committee aimed at fostering a culture of continuous learning and knowledge sharing within the company
-  - Co-organised 3 internal conferences, showcasing a total of 34 speakers to 500+ attendees <!--NOTE: Change organised to organized if applying in US-->
-  - Organised a continuous stream of technical talks by internal and external speakers, in addition to other initiatives and activities, keeping employees engaged and stimulated <!--NOTE: Change organised to organized if applying in US-->
+- Participated in pilot program for official mentorship initiative, suggesting improvements and solving logistic issues for full rollout of program
+- Took on multiple mentees simultaneously, totalling 5 to date
 
-- **Company blog** | Chief editor | 2020 – present
-  - Recruited authors internally and reviewed, edited and published posts, ensuring the company website had a steady stream of interesting and relevant content at a high standard of writing
+| **Assistant lecturer** | **University of Pretoria**  | **2013 – 2015** |
+| -- | -- | -- |
 
-- **Mentorship program** | Pilot participant and mentor | 2023 – present
-  - Participated in pilot program for official mentorship initiative, suggesting improvements and solving logistic issues for full rollout of program
-  - Took on multiple mentees simultaneously, totalling 5 to date
+<br/>
 
-**University of Pretoria** | Assistant lecturer | 2013 – 2015
+| **Net1 UEPS Technologies** | **Junior software developer** | **2012** |
+| -- | -- | -- |
 
-**University of Pretoria** | Tutor | 2010 – 2011
+<br/>
 
-**Net1 UEPS Technologies** | Junior software developer | 2012 
+| **Tutor** | **University of Pretoria** | **2010 – 2011** |
+| -- | -- | -- |
 
 ## Education
 
-Master of Science in Computer Science (Distinction) | University of Pretoria, South Africa | 2019 
+| Master of Science (Distinction) | University of Pretoria | 2019 | 
+| -- | -- | -- |
+| Computer Science | South Africa | |

--- a/resume.md
+++ b/resume.md
@@ -1,8 +1,7 @@
 # Phlippie Bosman
 
-[phlippie.bosman@gmail.com](mailto:phlippie.bosman@gmail.com) |
-[github.com/phlippieb](https://github.com/phlippieb) |
-[phlippieb.bearblog.dev](https://phlippieb.bearblog.dev)
+| [phlippie.bosman@gmail.com](mailto:phlippie.bosman@gmail.com) | [github.com/phlippieb](https://github.com/phlippieb) | [phlippieb.bearblog.dev](https://phlippieb.bearblog.dev) |
+| -- | -- | -- |
 
 ## Skills
 
@@ -10,11 +9,14 @@ Swift, Objective-C, iOS, Dart, Flutter, Bitrise, GitHub Actions, Firebase, Fastl
 
 ## Experience
 
-**Retro Rabbit Enterprise Services**  | Senior software developer | 2016 – present
+| **Retro Rabbit Enterprise Services**  | **Senior software developer** | **2016 – present** |
+| -- | -- | -- |
 
 Client projects:
 
-- **Discovery Limited – Health App** | Mobile technical lead | 2023 – 2024  
+| Discovery Limited – Health App | Mobile technical lead | 2023 – 2024 |
+| -- | -- | -- |
+
   - Co-led team of 8 implementing new Flutter-based mobile app for South Africa's largest medical scheme with 2.8M customers
   - Designed library of modules to be reusable company-wide through a process of proposing RFCs, writing abstract interfaces, and releasing standalone federated plugins
   - Instilled usage of BLoC, dependency injection, and feature flag patterns through reference implementations and code reviews

--- a/resume.md
+++ b/resume.md
@@ -1,6 +1,6 @@
 # Phlippie Bosman
 
-| [phlippie.bosman@gmail.com](mailto:phlippie.bosman@gmail.com) | [github.com/phlippieb](https://github.com/phlippieb) | [phlippieb.bearblog.dev](https://phlippieb.bearblog.dev) |
+| [`phlippie.bosman@gmail.com`](mailto:phlippie.bosman@gmail.com) | [`github.com/phlippieb`](https://github.com/phlippieb) | [`phlippieb.bearblog.dev`](https://phlippieb.bearblog.dev) |
 | -- | -- | -- |
 
 ## Skills
@@ -27,7 +27,7 @@ Swift, Objective-C, iOS, Dart, Flutter, Bitrise, GitHub Actions, Firebase, Fastl
 - Integrated in-house iOS-native biometric authentication SDK as a Flutter plugin, connecting native Swift code to Dart, improving user experience and aligning with organisation security standards <!--NOTE: Change organisation to organization if applying in US-->
 - Engaged stakeholders, converting business cases to road maps with linked issues, reporting regularly on install- and crash stats, and proactively communicating roadblocks  
 
-| *iOS technical lead* | *Discovery Limited* | *2022-2023* |
+| *iOS technical lead* | *Discovery Limited* | *2022 – 2023* |
 | -- | -- | -- |
 | Health Module for Mobile App | South Africa | |
 

--- a/resume.md
+++ b/resume.md
@@ -71,15 +71,24 @@ Swift, Objective-C, iOS, Dart, Flutter, Bitrise, GitHub Actions, Firebase, Fastl
 | **Assistant lecturer** | **University of Pretoria**  | **2013 – 2015** |
 | -- | -- | -- |
 
+- Prepared and presented lectures for undergraduate computer science modules
+- Set assessment tasks, including exams, tests, and exercises
+
 <br/>
 
-| **Net1 UEPS Technologies** | **Junior software developer** | **2012** |
+| **Junior software developer** | **Net1 UEPS Technologies** | **2012** |
 | -- | -- | -- |
+| Nedbank Team | South Africa | |
+
+- Investigated production incidents involving transactions through a major South African bank's point-of-sale transaction switch system
+- Performed maintenance work to align system to ISO standards updates
 
 <br/>
 
 | **Tutor** | **University of Pretoria** | **2010 – 2011** |
 | -- | -- | -- |
+
+- Assisted with practical lab sessions and assessment marking for undergraduate computer science modules
 
 ## Education
 


### PR DESCRIPTION
Part of #2 

3-column headers and general layouts

Still outstanding:

- [x] Information hierarchy: Differentiate top-level experience (Retro Rabbit) from projects (Discovery) somehow
- [x] Consider adding more info to headers, as per [example](https://blog.pragmaticengineer.com/the-pragmatic-engineers-resume-template/); specifically:  

| Role | Company | Date |
| - | - | - |
| Team/product | Location | |